### PR TITLE
[meta] Update ISSUE_TEMPLATE to explain spec shortnames

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,2 +1,8 @@
 * please tag the issue title with the spec's shortname, like `[css-foo]`
+  (this is the name from the spec URL, without a level number unless the issue is specific to that level).
+  If you're proposing a new feature that doesn't obviously fit in an existing spec, skip this part — don't make something up.
+
+* please be specific (in the title and issue) about what you want to change:
+  “make it better” means different things to different people!
+
 * please link to the spec section you're talking about, or at least the spec


### PR DESCRIPTION
Add some more guidance for new contributors, who might not understand what the spec shortnames are.